### PR TITLE
SECAA-1290: Bump CodeQL to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         if: github.repository_owner == 'ltvco'
         with:
           languages: ${{ matrix.language }}
@@ -51,7 +51,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
         if: github.repository_owner == 'ltvco'
 
       # ℹ️ Command-line programs to run using the OS shell.
@@ -66,7 +66,7 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         if: github.repository_owner == 'ltvco'
 
       - name: Send custom JSON data to Slack workflow


### PR DESCRIPTION
## Summary

CodeQL v2 will be deprecated in December 2024. Because of that, we need to update it to v3. The only difference is that v2 uses node 16, and v3 uses node 20.

Ticket: https://ltvco.atlassian.net/browse/SECAA-1290